### PR TITLE
fixed scrolling issue on low-res displays

### DIFF
--- a/src/gui/index.css
+++ b/src/gui/index.css
@@ -48,8 +48,6 @@ textarea {
 
 #app-container {
   display: flex;
-  height: 100vh;
-  overflow: hidden;
 }
 
 #left-panel {
@@ -60,7 +58,6 @@ textarea {
 #panel-container {
   display: flex;
   flex-direction: column;
-  height: 100vh;
 }
 
 #panel-top-container {


### PR DESCRIPTION
https://github.com/stuffmatic/fSpy/issues/33

Setting the height caused the overflow to be hidden, removing this allowed scrolling. This should fix the issues pointed out in the issue linked above.